### PR TITLE
Adds gulp for build support. Prep for bower.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+bower_components

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,31 @@
+{
+  "name": "glowscript",
+  "version": "v1.1.0",
+  "homepage": "http://www.glowscript.org/",
+  "authors": [
+    "Bruce Sherwood <bruce.sherwood@gmail.com>"
+  ],
+  "description": "GlowScript is an easy-to-use, powerful environment for creating 3D animations and publishing them on the web.",
+  "main": [
+    "package/glow.1.1.min.js",
+    "package/compiler.1.1.min.js",
+    "package/RSrun.1.1.min.js",
+    "package/RScompiler.1.1.min.js"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/BruceSherwood/glowscript.git"
+  },
+  "keywords": [
+    "vpython",
+    "webgl",
+    "javascript"
+  ],
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,84 @@
+var gulp   = require('gulp')
+  , uglify = require('gulp-uglify')
+  , concat = require('gulp-concat-util')
+  , wrap   = require('gulp-wrap')
+  , tap    = require('gulp-tap')
+  , header = require('gulp-header')
+  , path   = require('path')
+  , version
+  , glowscript_libraries;
+
+version = '1.1';
+
+glowscript_libraries = {
+  "glow": [
+    "lib/jquery/jquery.mousewheel.js",
+    "lib/flot/jquery.flot.min.js",
+    "lib/flot/jquery.flot.crosshair_GS.js",
+    "lib/glMatrix.js",
+    "lib/webgl-utils.js",
+    "lib/glow/property.js",
+    "lib/glow/vectors.js",
+    "lib/glow/mesh.js",
+    "lib/glow/canvas.js",
+    "lib/glow/orbital_camera.js",
+    "lib/glow/autoscale.js",
+    "lib/glow/WebGLRenderer.js",
+    "lib/glow/graph.js",
+    "lib/glow/color.js",
+    "lib/glow/primitives.js",
+    "lib/glow/api_misc.js",
+    "lib/glow/shaders.gen.js"
+  ],
+  "compiler": [
+    "lib/narcissus/lib/jsdefs.js",
+    "lib/narcissus/lib/jslex.js",
+    "lib/narcissus/lib/jsparse.js",
+    "lib/narcissus/lib/jsdecomp.js",
+    "lib/streamline/compiler/format.js",
+    "lib/streamline/compiler/transform.js",
+    "lib/compiler.js",
+    "lib/coffee-script.js"
+  ],
+  "RSrun": [
+    "lib/rapydscript/stdlib.js"
+  ],
+  "RScompiler": [
+    "lib/narcissus/lib/jsdefs.js",
+    "lib/narcissus/lib/jslex.js",
+    "lib/narcissus/lib/jsparse.js",
+    "lib/narcissus/lib/jsdecomp.js",
+    "lib/streamline/compiler/format.js",
+    "lib/streamline/compiler/transform.js",
+    "lib/compiler.js",
+    "lib/rapydscript/utils.js",
+    "lib/rapydscript/ast.js",
+    "lib/rapydscript/output.js",
+    "lib/rapydscript/parse.js",
+    "lib/rapydscript/baselib.js",
+    "lib/rapydscript/stdlib.js"
+  ],
+};
+
+gulp.task('default', function() {
+  var shaders = []
+    , shader_key;
+
+  gulp.src('./shaders/*.shader')
+    .pipe(tap(function(file) {
+      shader_key = path.basename(file.path, '.shader');
+      file.contents = new Buffer('"' + shader_key + '":' + JSON.stringify(file.contents.toString()));
+      return file;
+    }))
+    .pipe(concat('shaders.gen.js', { sep : ',\n' }))
+    .pipe(wrap('Export({ shaders: {\n<%= contents %>\n}});'))
+    .pipe(gulp.dest('./lib/glow/'));
+
+  Object.keys(glowscript_libraries).forEach(function(lib) {
+    gulp.src(glowscript_libraries[lib])
+      .pipe(uglify())
+      .pipe(concat(lib + '.' + version + '.min.js'))
+      .pipe(header("/*This is     a combined, compressed file.  Look at https://github.com/BruceSherwood/glowscript for source code and copyright information.*/"))
+      .pipe(gulp.dest('./package/'));
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "glowscript",
+  "version": "1.1.0",
+  "description": "GlowScript is an easy-to-use, powerful environment for creating 3D animations and publishing them on the web.",
+  "main": "package/glow.1.1.min.js",
+  "directories": {
+    "doc": "docs",
+    "example": "examples"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/BruceSherwood/glowscript.git"
+  },
+  "keywords": [
+    "vpython",
+    "webgl",
+    "javascript"
+  ],
+  "author": "Bruce Sherwood <bruce.sherwood@gmail.com>",
+  "bugs": {
+    "url": "https://github.com/BruceSherwood/glowscript/issues"
+  },
+  "homepage": "https://github.com/BruceSherwood/glowscript",
+  "devDependencies": {
+    "gulp": "^3.8.11",
+    "gulp-concat": "^2.5.2",
+    "gulp-concat-util": "^0.5.2",
+    "gulp-header": "^1.2.2",
+    "gulp-tap": "^0.1.3",
+    "gulp-uglify": "^1.2.0",
+    "gulp-wrap": "^0.11.0"
+  }
+}


### PR DESCRIPTION
No changes here to the core but does add support for using `gulp` which could replace the python `build.py` script. Just install [gulp](http://gulpjs.com/) globally using `npm install -g gulp`. Then run `npm install` locally. Finally, just run `gulp` to build. This should provide an easy replacement for `build.py` and work seamlessly across platforms.

Also added is a `bower.json` file. Great thing about [bower](http://bower.io/) is that once a package is registered it makes it very easy to manage dependencies and to install.

Assuming bower is installed (to install use `npm install -g bower`) run this to register:

`bower register glowscript git://github.com/BruceSherwood/glowscript.git`

This just registers the package so that others can use it locally by running `bower install glowscript`. This is how we would use it at trinket. This does not yet provide good version management support but it sets things up to add that in later.