### PR TITLE
Fix label behavior in primitives.js

### DIFF
--- a/lib/glow/primitives.js
+++ b/lib/glow/primitives.js
@@ -1998,15 +1998,14 @@
             } else {
                 if (this.canvas.__width >= this.canvas.__height) var factor = 2 * this.canvas.__range / this.canvas.__height // real coord per pixel
                 else var factor = 2 * this.canvas.__range / this.canvas.__width
-                var vnew = mat4.multiplyVec3(
-                    mat4.rotateY(mat4.rotateX(mat4.identity(mat4.create()), camera.angleY), camera.angleX),
-                    vec3.create([this.pos.x - this.canvas.center.x, this.pos.y - this.canvas.center.y, this.pos.z - this.canvas.center.z]))
+                var viewMatrix = mat4.lookAt(camera.pos, camera.target, camera.up)
+                var vnew = mat4.multiplyVec3(viewMatrix, vec3.create([this.pos.x, this.pos.y, this.pos.z]))
+                // Check for wrap-around or out-of-range label
+                if (vnew[2] > -camera.zNear || vnew[2] < -camera.zFar) return
                 var d = camera.distance
-                var k = (1 + vnew[2] / (d - vnew[2])) / factor
+                var k = -d/(vnew[2]*factor)
                 posx = Math.round(k * vnew[0] + this.canvas.__width / 2) // label.pos in terms of pixels
                 posy = Math.round(-k * vnew[1] + this.canvas.__height / 2)
-                // Need to check for wrap-around of label, but this isn't right:
-                //if (vnew[2] < camera.zNear || vnew[2] > camera.zFar) return
             }
 
             ctx.font = this.__height + 'px ' + this.__font


### PR DESCRIPTION
Labels weren't scaling/rotating correctly when camera.up wasn't +y.
Also added back in label clipping when outside of camera range.
