### PR TITLE
Fixed 'Sign-In' Cancel Bug.

### DIFF
--- a/css/ide.css
+++ b/css/ide.css
@@ -232,6 +232,10 @@ a.button
 	color: Blue;
 }
 
+.no-close .ui-dialog-titlebar-close {
+    display: none;
+}
+
 .template
 {
 	display:none

--- a/ide/api.py
+++ b/ide/api.py
@@ -133,6 +133,13 @@ class ApiLogin(ApiRequest):
             if "@" in nickname: nickname = nickname.split("@",2)[0]
             self.respond( { 'state':'new_user', 'suggested_name':nickname } )
 
+class ApiLoginAbort(ApiRequest):
+    allowJSONP = None
+
+    def get(self):
+        if not self.authorize(): return
+        self.respond( { 'logout_url':users.create_logout_url("/#/action/loggedout") } )
+
 class ApiUsers(ApiRequest):
     def get(self):
         if not self.authorize(): return
@@ -192,6 +199,7 @@ class ApiUserFolders(ApiRequest):
         if not self.validate(user): return
         gaeUser = users.get_current_user()
         db_user = User.get( db.Key.from_path("User",user) )
+
         folders = []
         for k in Folder.all().ancestor(db.Key.from_path("User",user)):
         	if k.isPublic != None and not k.isPublic and gaeUser != db_user.gaeUser: continue
@@ -345,6 +353,7 @@ app = web.WSGIApplication(
         (r'/api/user/', ApiUsers),
 
         (r'/api/login', ApiLogin),
+        (r'/api/abort', ApiLoginAbort),
 
         (r'/api/admin/upgrade', ApiAdminUpgrade),
     ],

--- a/ide/ide.js
+++ b/ide/ide.js
@@ -99,13 +99,15 @@ $(function () {
     }
     function apiURL( route ) {
         if (route.login !== undefined)
-            return 'api/login'
+            return 'api/login';
+        if (route.abort !== undefined)
+            return 'api/abort';
         if (route.user !== undefined) {
-            var u = "api/user/" + encode(route.user)  // user might be LIST, to get the list
+            var u = "api/user/" + encode(route.user);  // user might be LIST, to get the list
             if (route.folder !== undefined) {
-                u += "/folder/" + encode(route.folder)  // folder might be LIST, to get the list
+                u += "/folder/" + encode(route.folder);  // folder might be LIST, to get the list
                 if (route.program !== undefined) {
-                    u += "/program/" + encode(route.program)  // program might be LIST, to get the list
+                    u += "/program/" + encode(route.program);  // program might be LIST, to get the list
                 }
             }
             return u;
@@ -307,6 +309,7 @@ $(function () {
 
             $dialog.dialog({
                 width: 300,
+                dialogClass: "no-close",
                 modal: true,
                 autoOpen: true,
                 buttons: {
@@ -326,7 +329,12 @@ $(function () {
                             }
                         })
                     },
-                    //"Cancel": function () { $(this).dialog("close"); }
+                    "Abort": function () {
+                        $(this).dialog("close");
+                        apiGet({abort:1}, function(stat) {
+                            window.location.assign(stat.logout_url);    // Go to logout url. Maybe its better to use redirect().
+                        })
+                    }
                 },
                 close: function () { }
             }).submit(function(ev){


### PR DESCRIPTION
Previously, once signed in _for the first time_ but before choosing a nickname, abort was not possible.
Issue resolved by adding Abort button and sending logout command on Abort.
Close ("X") button disabled to prevent exit without abort.