### PR TITLE
Fixed bug in getLoginStatus().

### DIFF
--- a/ide/ide.js
+++ b/ide/ide.js
@@ -232,8 +232,11 @@ $(function () {
     onNavigate.on( getLoginStatus )
     function getLoginStatus( cb ) {
         apiGet({login:1}, function(stat) {
-            onLoginStatusChange(stat)
-            cb() 
+            if (stat === null) {getLoginStatus(cb); return;}
+            else {
+              onLoginStatusChange(stat);
+              cb();
+            }
         })
     }
     function onLoginStatusChange(stat) {
@@ -243,11 +246,7 @@ $(function () {
         // stat = {state: "not_logged_in", login_url: "/_ah/login?continue=http%3A//localhost%3A8080/%23/action/loggedin"}
         // stat = {username: "test", state: "logged_in", secret: "qwie9Mnddk0zYnz3Qxov7g==", 
         //              logout_url: "/_ah/login?continue=http%3A//localhost%3A8080/%23/action/loggedout&action=Logout"}
-        if (stat === null) {  // Apparently timing issues can lead to stat === null at startup
-            stat = {'state': 'checking'}
-            window.onhashchange() // try again
-        }
-        loginStatus = stat
+        loginStatus = stat;
         if (loginStatus.username) loginStatus.username = decode(loginStatus.username)
 
         var $userstatus = $(".userstatus")


### PR DESCRIPTION
Call to windows.onhashchange insufficient to ensure 're-verify' of loginStatus in case getLoginStatus returns null.
Changed so getLoginStatus calls itself back until it gets a value other than null.
No issues with onNavigate.trigger, because 'count' value will hold until getLoginStatus() finally returns a non-null value.
The old handing method was also removed.