### PR TITLE
Major Feature: Pin Favorite Non-owned Folders

### DIFF
--- a/css/ide.css
+++ b/css/ide.css
@@ -439,3 +439,9 @@ a.button
   background: rgb(250, 250, 255);
   border: 1px solid rgb(200, 200, 250);
 }
+
+.ide-state-non-owned
+{
+    background: #f0e5ff; /* url("ui-bg_flat_55_f0e5ff_40x100.png") 50% 50% repeat-x; */
+	border: 1px solid #c8bfe7;  /* OLD WAS #a098b8 */
+}

--- a/ide/api.py
+++ b/ide/api.py
@@ -51,7 +51,7 @@ class User (db.Model):
     joinDate = db.DateTimeProperty(auto_now_add=True)
     gaeUser = db.UserProperty()
     secret = db.StringProperty(indexed=False)
-    pinned = db.StringListProperty(indexed=False, default=["GlowScriptDemos/Examples"])
+    pinned = db.StringListProperty(indexed=False) #, default=["GlowScriptDemos/Examples"])
 
 class Folder (db.Model):
     """A collection of programs created by a user"""
@@ -176,6 +176,7 @@ class ApiUser(ApiRequest):
         # TODO: Make sure *nothing* exists in the database with an ancestor of this user, just to be sure
 
         db_user = User( key_name = username, gaeUser = gaeUser, secret = base64.urlsafe_b64encode(os.urandom(16)) )
+        if username != 'GlowScriptDemos': db_user.pinned=["GlowScriptDemos/Examples"]
         db_user.put()
 
         db_my_programs = Folder( parent = db_user, key_name = "Public", isPublic=True )

--- a/ide/api.py
+++ b/ide/api.py
@@ -51,6 +51,7 @@ class User (db.Model):
     joinDate = db.DateTimeProperty(auto_now_add=True)
     gaeUser = db.UserProperty()
     secret = db.StringProperty(indexed=False)
+    pinned = db.StringListProperty(indexed=False, default=["GlowScriptDemos/Examples"])
 
 class Folder (db.Model):
     """A collection of programs created by a user"""
@@ -197,7 +198,9 @@ class ApiUserFolders(ApiRequest):
         	if k.isPublic != None and not k.isPublic and gaeUser != db_user.gaeUser: continue
         	folders.append(k.key().name())
         #folders = [ k.name() for k in Folder.all(keys_only=True).ancestor(db.Key.from_path("User",user)) ]
-        self.respond( {"user" : user, "folders" : folders} )
+        if gaeUser == db_user.gaeUser:
+            folders.extend(db_user.pinned)
+        self.respond( {"user": user, "folders": folders} );
 
 class ApiUserFolder(ApiRequest):
     def put(self, user, folder):                                                ##### create a new folder
@@ -233,6 +236,33 @@ class ApiUserFolder(ApiRequest):
             return self.error(409)
         db_folder.delete()
 
+class ApiUserFolderPin(ApiRequest):
+    def put(self, user, folder):
+        m = re.search(r'/user/([^/]+)/folder/([^/]+)/(unpin|pin)', self.request.path)
+        user = m.group(1)
+        folder = m.group(2)
+        toPin = True if m.group(3) == 'pin' else False
+        if not self.authorize(): return
+        if not self.validate(user, folder): return
+        gaeUser = users.get_current_user()
+        if not gaeUser:
+            return self.error(403)
+        db_user = User.gql("WHERE gaeUser = :gaeUser", gaeUser=gaeUser).get()
+        if not db_user:
+            return self.error(405)
+        db_folder = Folder.get(db.Key.from_path("User",user,"Folder",folder))
+        if not db_folder:
+            return self.error(404)
+        pinpath = user+r'/'+folder
+        if (toPin and (not pinpath in db_user.pinned)):
+            db_user.pinned.append(pinpath)
+            db_user.pinned.sort()
+            db_user.put()
+        elif ((not toPin) and (pinpath in db_user.pinned)):
+            db_user.pinned.remove(pinpath)
+            db_user.put()
+        #self.respond(db_user.pinned)
+        
 class ApiUserFolderPrograms(ApiRequest):
     def get(self, user, folder):                                                ##### display all programs in a public or owned folder
         m = re.search(r'/user/([^/]+)/folder/([^/]+)', self.request.path)
@@ -345,6 +375,9 @@ app = web.WSGIApplication(
         (r'/api/user/', ApiUsers),
 
         (r'/api/login', ApiLogin),
+
+        (r'/api/user/([^/]+)/folder/([^/]+)/pin', ApiUserFolderPin),        # AST - Pins non-owned folder for regular access!
+        (r'/api/user/([^/]+)/folder/([^/]+)/unpin', ApiUserFolderPin),      # AST - Unpins non-owned folder for regular access!
 
         (r'/api/admin/upgrade', ApiAdminUpgrade),
     ],

--- a/ide/ide.js
+++ b/ide/ide.js
@@ -106,6 +106,10 @@ $(function () {
                 u += "/folder/" + encode(route.folder)  // folder might be LIST, to get the list
                 if (route.program !== undefined) {
                     u += "/program/" + encode(route.program)  // program might be LIST, to get the list
+                } else if (route.pin == 1) {
+                    u += "/pin";
+                } else if (route.pin == 0) {
+                    u += "/unpin";
                 }
             }
             return u;
@@ -170,11 +174,60 @@ $(function () {
             }
         })
     }
-    var folderList = null
+
+    var pinnedFolderList = null;
     function getFolderList(username, callback) {
-        if (folderList) callback(folderList)
-        apiGet({user:username, folder:LIST}, function (nfl) { folderList = nfl; callback(nfl); })
+        var folderSets = [];
+        var isLoggedIn = ( loginStatus.state === "logged_in" );
+        var isWritable = ( username === loginStatus.username );
+        if (pinnedFolderList) {
+            folderSets.push.apply(folderSets, pinnedFolderList);
+        } else if (!pinnedFolderList && isLoggedIn) {
+            apiGet({user:loginStatus.username, folder:LIST}, function (nfl) {
+                pinnedFolderList = [];
+                pinnedFolderList.push.apply(pinnedFolderList,decodeFolderPins(nfl));
+                getFolderList(username, callback);
+            });
+            return;
+        }
+        if (isWritable) {
+            folderSets.push({user:"", folders:[]});
+            callback(folderSets);
+        } else apiGet({user:username, folder:LIST}, function (nfl) {
+            for (var i = 1; i < folderSets.length; i++) {
+                if (folderSets[i].user == nfl.user) {
+                    for (var j = 0; j < folderSets[i].folders.length; j++) {
+                        var n = nfl.folders.indexOf(folderSets[i].folders[j]);
+                        if (n > -1) nfl.folders.splice(n,1);
+                    }
+                    break;
+                }
+            }
+            folderSets.push(nfl);
+            callback(folderSets);
+        })
     }
+    
+    function decodeFolderPins(nfl) {
+        var fo = []; fo.push({user: nfl.user, folders: []});
+        var fu = []; fu.push(nfl.user);
+        for (var n = 0; n < nfl.folders.length; n++) {
+            if ( nfl.folders[n].indexOf("/") == -1 ) {fo[0].folders.push(nfl.folders[n]);}
+            else {
+                var spl = nfl.folders[n].split("/");
+                var i = fu.indexOf(spl[0])
+                if (i == -1) {
+                    fu.push(spl[0]);
+                    fo.push({user: spl[0], folders: [] });
+                    fo[fo.length-1].folders.push(spl[1]);
+                } else {
+                    fo[i].folders.push(spl[1]);
+                }
+            }
+        }
+        return fo;
+    }
+    
     function saver(uri, getProgramSource, setStatus) {
         var saveTimeout = null
         var saving = false
@@ -446,17 +499,17 @@ $(function () {
         redirect( {page: "welcome"} )
     }
     pages.folder = function (route) {
-        var username = route.user, folder = route.folder
-        var isWritable = route.user === loginStatus.username
+        var username = route.user, folder = route.folder;
+        var isWritable = (route.user === loginStatus.username);
+        var isLoggedIn = (loginStatus.state === "logged_in");
 
-        var page = $(".folderPage.template").clone().removeClass("template")
-        var programTemplate = page.find(".program.template")
-        var folderTemplate = page.find(".folderListItem.template")
+        var page = $(".folderPage.template").clone().removeClass("template");
+        var programTemplate = page.find(".program.template");
+        var folderTemplate = page.find(".folderListItem.template");
 
-        if (!isWritable) {
-            page.find(".program-new.button").addClass("template")
-            page.find(".folder-new-tab").addClass("template")
-        }
+        if (!isWritable) page.find(".program-new.button").addClass("template");
+
+        if (!isLoggedIn) page.find(".folder-new-tab").addClass("template");
 
         page.find(".username").text(username) // + ", IDE jQuery ver. " + jQuery.fn.jquery) // To show IDE jQuery version number at top of IDE during run.
         page.find(".foldername").text(folder)
@@ -517,8 +570,9 @@ $(function () {
                 name = name.replace(/ /g,'') // There are problems with spaces or underscores in names
                 name = name.replace(/_/g,'')
                 var p = $dlg.find('input[name="isPublic"]').is(":checked") // true is checked, which means public
-                apiPut({user:username, folder:name}, {public:p}, function () {
-                    navigate( {page:"folder", user:username, folder:name} )
+                pinnedFolderList=null;
+                apiPut({user:loginStatus.username, folder:name}, {public:p}, function () {
+                    navigate( {page:"folder", user:loginStatus.username, folder:name} )
                 })
             })
             return false;
@@ -527,6 +581,7 @@ $(function () {
         page.find(".folder-delete").click(function (ev) {
             ev.preventDefault();
             return delProgramOrFolder("#folder-delete-dialog", folder, function() {
+                pinnedFolderList=null;
                 apiDelete( {user:username, folder:folder}, function () {
                     navigate( {page:"user", user:username} )                
                 })                
@@ -546,17 +601,34 @@ $(function () {
             return false;
         })
 
-        // Get a list of folders.  May return multiple times if list is updated
-        getFolderList(username, function (data) {
-            page.find(".folderList > .templated").remove()
-            var before = folderTemplate.next()
-            var folders = data.folders
-            for (var i = 0; i < folders.length; i++) {
-                var h = folderTemplate.clone().removeClass("template").addClass("templated")
-                var name = decode(folders[i])
-                if (name == folder) h.addClass("ui-tabs-active").addClass("ui-state-active")
-                h.find(".folder-name").text(name).prop("href", unroute({page:"folder", user:username, folder:name}))
-                h.insertBefore(before)
+        // Get a list of non-owned folders, user-owned folders, and pinned folders.
+        // Pass the list to the folder-tab creator.
+        getFolderList(username, function(data) {
+            page.find(".folderList > .templated").remove();
+            var newFolder = folderTemplate.next();
+            for (var i = 0; i < data.length; i++) {
+                var folders = data[i].folders;
+                for (var j = 0; j < folders.length; j++) {
+                    var h = folderTemplate.clone().removeClass("template").addClass("templated");
+                    var name = decode(folders[j]);
+                    if (((i == 0 && isWritable) || (i > 0 && username == data[i].user)) && name == folder) h.addClass("ui-tabs-active").addClass("ui-state-active");
+                    if (i == 0) {   // TODO: Setup program sorting in owned folders.
+                    } else {  // if more than one grouping of folders
+                        h.addClass("ide-state-non-owned");
+                        h.children("a").first().prop('title','Owned by '+data[i].user+'.');
+                        var hpin = h.children("input").first();
+                        if (i<data.length-1) hpin.prop("checked", true);
+                        hpin.removeClass("template")
+                        hpin.data({'username': data[i].user, 'folder': name});
+                        hpin.click(function(){
+                            pinnedFolderList = null;
+                            var pinroute = { user: $(this).data('username'), folder: $(this).data('folder'), pin: $(this).is(":checked")?1:0 };
+                            apiPut( pinroute, {}, function(pinned) { /*console.log(pinned);*/ })
+                        });
+                    }
+                    h.find(".folder-name").text(name).prop("href", unroute({page:"folder", user:data[i].user, folder:name}));
+                    h.insertBefore(newFolder);
+                }
             }
         })
 

--- a/ide/index.html
+++ b/ide/index.html
@@ -98,7 +98,7 @@ Loading...
             <span class="username">User</span>'s <a href="#/">GlowScript</a> Programs
             <div class="folderTabs ui-tabs ui-widget">
                 <ul class="folderList ui-tabs-nav ui-helper-reset ui-helper-clearfix ui-corner-all">
-                    <li class="folderListItem template ui-state-default ui-corner-top"><a class="folder-name"></a></li>
+                    <li class="folderListItem template ui-state-default ui-corner-top"><a class="folder-name"></a><input name="pin" type="checkbox" value="" class="template"></li>
                     <li class="folder-new-tab ui-state-default ui-corner-top"><a href="#newFolder" class="folder-new">Add Folder</a></li>
                 </ul>
                 <div id="Public" style="display:none"></div>


### PR DESCRIPTION
Previously, when visiting the folder of another user, only that user's folders are shown.

Added feature such that the logged-in user's folders are also shown (side-by-side with the non-owned folders).
The tab is tinted, a tooltip is added to specify ownership, and non-owned folders are protected.
Each non-owned folder has a checkbox. If checked, the folder will appear any time user is logged in, along with owned folders.

Set "GlowscriptDemos/Examples" as default pinned folder. Was unable to test without web deployment, but should work like any user.