### PR TITLE
no need to keep nagging about putting .pyc files in .git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 bower_components
+*.pyc
+


### PR DESCRIPTION
Hi Bruce,

I was starting to learn my way around glowscript and I noticed these .pyc files were getting flagged as 'new files' to be added to the repository. Obviously this is trivial, but also annoying. ;-) Hope you don't mind ignoring them.

-steve
