### PR TITLE
Blake - Fixing markdown hrefs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,17 @@ That's it. That's the whole program (except for the GlowScript version header li
 
 Documentation
 -------------
-At [glowscript.org] (http://glowscript.org) click Help for full documentation. There is an extensive set of example programs available from the first page of glowscript.org. Programs can be created and stored at glowscript.org, but it is also possible to export a program to place on your own web page, or to use the GlowScript library without storing the program at glowscript.org. For programs stored at glowscript.org, you can share a link with someone and they can run your program simply by clicking on the link. Here is an example:
+At [glowscript.org](http://glowscript.org) click Help for full documentation. There is an extensive set of example programs available from the first page of glowscript.org. Programs can be created and stored at glowscript.org, but it is also possible to export a program to place on your own web page, or to use the GlowScript library without storing the program at glowscript.org. For programs stored at glowscript.org, you can share a link with someone and they can run your program simply by clicking on the link. Here is an example:
 
    http://www.glowscript.org/#/user/GlowScriptDemos/folder/Examples/program/Bounce-VPython
 
-GlowScript was inspired by [VPython](http://vpython.org). The project was begun in 2011 by David Scherer and Bruce Sherwood. Originally programs had to be written in JavaScript, but in November 2014 it became possible to use Python, thanks to the [RapydScript](https://github.com/atsepkov/RapydScript) Python-to-JavaScript compiler created by Alex Tsepkov. GlowScript is now using a later version, [RapydScript-ng] (https://github.com/kovidgoyal/rapydscript-ng) developed by Kovid Goyal.
+GlowScript was inspired by [VPython](http://vpython.org). The project was begun in 2011 by David Scherer and Bruce Sherwood. Originally programs had to be written in JavaScript, but in November 2014 it became possible to use Python, thanks to the [RapydScript](https://github.com/atsepkov/RapydScript) Python-to-JavaScript compiler created by Alex Tsepkov. GlowScript is now using a later version, [RapydScript-ng](https://github.com/kovidgoyal/rapydscript-ng) developed by Kovid Goyal.
 
 For information related to building the GlowScript application, see MakingNewVersion.txt in the docs folder.
 
 Sister Project
 --------------
-A more recent project initiated by John Coady and further developed by Ruth Chabay and Bruce Sherwood lets you run VPython programs in a Jupyter notebook: see [vpython.org] (http://vpython.org). The syntax is the same as GlowScript VPython, but Jupyter VPython uses an installed standard Python, which provides access to the large number of Python modules. GlowScript VPython does not require installing any software but provides access only to libraries written in JavaScript, not to standard Python modules.
+A more recent project initiated by John Coady and further developed by Ruth Chabay and Bruce Sherwood lets you run VPython programs in a Jupyter notebook: see [vpython.org](http://vpython.org). The syntax is the same as GlowScript VPython, but Jupyter VPython uses an installed standard Python, which provides access to the large number of Python modules. GlowScript VPython does not require installing any software but provides access only to libraries written in JavaScript, not to standard Python modules.
  
 Run a Local Server
 ------------------


### PR DESCRIPTION
Removes spaces in documentation that were causing improper href rendering. If there is an empty space between the [] and the (), markdown will read it as separate words and not render an href.

```
[glowscript.org] (http://glowscript.org) 
```
to
```
[glowscript.org](http://glowscript.org) 
```